### PR TITLE
Disable driver debug output by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,11 @@ ifeq ($(CONFIG_PCI_HCI), y)
 HCI_NAME = pci
 endif
 
+ifeq ($(DEBUG), 1)
+EXTRA_CFLAGS += -DDBG=1 -DCONFIG_DEBUG
+else
+EXTRA_CFLAGS += -DDBG=0
+endif
 
 _OS_INTFS_FILES :=	os_dep/osdep_service.o \
 			os_dep/linux/os_intfs.o \

--- a/include/autoconf.h
+++ b/include/autoconf.h
@@ -348,9 +348,9 @@
 /*
  * Debug Related Config
  */
-#define DBG	1
+//#define DBG	1
 
-#define CONFIG_DEBUG /* DBG_871X, etc... */
+//#define CONFIG_DEBUG /* DBG_871X, etc... */
 //#define CONFIG_DEBUG_RTL871X /* RT_TRACE, RT_PRINT_DATA, _func_enter_, _func_exit_ */
 
 #define DBG_CONFIG_ERROR_DETECT


### PR DESCRIPTION
Use 'make DEBUG=1' to enable debug output